### PR TITLE
feat: define allowed registry prefixes in rule_data.yml

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -1,0 +1,5 @@
+---
+rule_data:
+  # Usage: https://conforma.dev/docs/policy/packages/release_base_image_registries.html#base_image_registries__allowed_registries_provided
+  allowed_registry_prefixes:
+  - quay.io/fedora/fedora/


### PR DESCRIPTION
Adds `rule_data.yml` with `allowed_registry_prefixes` required by the `base_image_registries.allowed_registries_provided` Conforma policy.

Includes `quay.io/fedora/fedora` as it's the base image used by fcos-buildroot.