### PR TITLE
fix(rule_data): remove trailing slash from registry prefix

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -2,4 +2,4 @@
 rule_data:
   # Usage: https://conforma.dev/docs/policy/packages/release_base_image_registries.html#base_image_registries__allowed_registries_provided
   allowed_registry_prefixes:
-  - quay.io/fedora/fedora/
+  - quay.io/fedora/fedora


### PR DESCRIPTION
Conforma rejects registry prefixes with a trailing slash. Updated to match expected format.