### PR TITLE
rule_data: allow bootc-devel f43 image

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -3,6 +3,7 @@ rule_data:
   # Usage: https://conforma.dev/docs/policy/packages/release_base_image_registries.html#base_image_registries__allowed_registries_provided
   allowed_registry_prefixes:
   - quay.io/fedora/fedora
+  - quay.io/bootc-devel/fedora-bootc-43-standard
   
   # Known RPM repositories used to validate sources.
   # Generated with:


### PR DESCRIPTION
The Conforma ICS is currently failing because the bootc-devel F43 base image is disallowed:

[Violation] base_image_registries.base_image_permitted Reason: Base image is from a disallowed registry
Term: quay.io/bootc-devel/fedora-bootc-43-standard